### PR TITLE
[3.9] Permissions Dropdown Not Working

### DIFF
--- a/editcomp.php
+++ b/editcomp.php
@@ -203,10 +203,14 @@ if ($compclass->plugins) {
     print_string('add');
     echo ': &nbsp;';
 
-    $attributes = ['id' => 'menuplugin'];
+    $attributes = [
+        'id' => 'menuplugin',
+        'data-id' => $id,
+        'data-comp' => $comp,
+        'onchange' => "M.block_configurable_reports.onchange_menuplugin(this)",
+    ];
 
     echo \html_writer::select($optionsplugins, 'plugin', '', ['' => get_string('choose')], $attributes);
-    $OUTPUT->add_action_handler(new component_action('change', 'menuplugin', ['url' => "editplugin.php?id=".$id."&comp=".$comp."&pname="]), 'menuplugin');
     echo '</p>';
     echo '</div>';
 }

--- a/js/configurable_reports.js
+++ b/js/configurable_reports.js
@@ -170,10 +170,12 @@ M.block_configurable_reports = {
                 }
             }
         });
+    },
+
+    onchange_menuplugin: function(selectElement) {
+        const id = selectElement.dataset.id;
+        const comp = selectElement.dataset.comp;
+
+        location.href = `editplugin.php?id=${id}&comp=${comp}&pname=${selectElement.value}`;
     }
 }
-
-function menuplugin(event,args) {
-    location.href = args.url+document.getElementById('menuplugin').value;
-}
-


### PR DESCRIPTION
Replace action handler with regular `onchange` callback to correct non-working change binding.