### PR TITLE
GS-100 Organisation Hierarchy Filters

### DIFF
--- a/classes/local/plugin/org_filter_base.php
+++ b/classes/local/plugin/org_filter_base.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace block_configurable_reports\local\plugin;
+
+global $CFG;
+
+use coding_exception;
+use dml_exception;
+use MoodleQuickForm;
+use plugin_base;
+use stdClass;
+use tool_organisation\persistent\hierarchy;
+use tool_organisation\persistent\level;
+
+require_once("$CFG->dirroot/blocks/configurable_reports/plugin.class.php");
+
+abstract class org_filter_base extends plugin_base {
+
+    /**
+     * Get the condensed name of the filter.
+     * Used for language strings, identifier, etc.
+     *
+     * @return string Name of the filter.
+     */
+    protected abstract static function get_name(): string;
+
+    /**
+     * Output filter fields to report form.
+     *
+     * @param MoodleQuickForm $mform Report form.
+     * @param stdClass $data Filter data.
+     * @return void
+     * @throws coding_exception
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public abstract function print_filter(MoodleQuickForm $mform, stdClass $data): void;
+
+    /**
+     * Initialise filter.
+     *
+     * @return void
+     * @throws coding_exception
+     */
+    public function init(): void {
+        $this->unique = true;
+        $this->fullname = static::get_string('name');
+    }
+
+    /**
+     * Get summary of the filter.
+     *
+     * @param stdClass $data Filter data.
+     * @return string Summary of the filter.
+     * @throws coding_exception
+     */
+    public function summary($data): string {
+        return static::get_string('summary');
+    }
+
+    /**
+     * Execute the filter.
+     *
+     * @param array|string $final_elements Content to be filtered.
+     * @param stdClass $data Filter data
+     * @return array|string Filtered content.
+     * @throws coding_exception
+     * @throws dml_exception
+     */
+    public function execute($final_elements, stdClass $data) {
+        $filter_value = self::get_form_value();
+        if (empty($filter_value)) {
+            return $final_elements;
+        }
+
+        if ($this->report->type === 'sql') {
+            return static::execute_sql($final_elements, $data, $filter_value);
+        }
+
+        return static::execute_users($final_elements, $data, $filter_value);
+    }
+
+    /**
+     * Execute filter for SQL reports.
+     *
+     * @param string $final_elements Content to be filtered.
+     * @param stdClass $data Filter data.
+     * @param int[] $filter_value Filter values.
+     * @return string Filtered content.
+     * @noinspection PhpUnusedParameterInspection
+     */
+    protected static function execute_sql(string $final_elements, stdClass $data, array $filter_value): string {
+        $match_name = strtoupper(static::get_name());
+
+        preg_match("/%%FILTER_$match_name:([^%]+)%%/i", $final_elements, $matches);
+        if (!$matches) {
+            return $final_elements;
+        }
+
+        $values = implode(',', $filter_value);
+        $replace = " and $matches[1] in ($values)";
+
+        return str_replace(
+            "%%FILTER_$match_name:$matches[1]%%",
+            $replace,
+            $final_elements
+        );
+    }
+
+    /**
+     * Execute filter for user reports.
+     *
+     * @param int[] $final_elements Content to be filtered.
+     * @param stdClass $data Filter data.
+     * @param int[] $filter_value Filter values.
+     * @return int[] Filtered content.
+     * @throws coding_exception
+     * @throws dml_exception
+     * @noinspection PhpUnusedParameterInspection
+     */
+    protected static function execute_users(array $final_elements, stdClass $data, array $filter_value): array {
+        global $DB;
+
+        [ $user_sql, $user_params ] = $DB->get_in_or_equal($final_elements);
+        [ $level_sql, $level_params ] = $DB->get_in_or_equal($filter_value);
+
+        return $DB->get_fieldset_sql(
+            "
+                select  users.id
+                from    {user} users
+                        join {tool_organisation_assign} assignments on
+                            assignments.userid = users.id
+                        join {tool_organisation_positions} positions on
+                            positions.id = assignments.positionid
+                        join {tool_organisation_level_data} level_data on
+                            level_data.positionid = positions.id or
+                            level_data.assignid = assignments.id
+                where   users.id $user_sql and
+                        level_data.levelid $level_sql
+            ",
+            array_merge(
+                $user_params,
+                $level_params,
+            )
+        );
+    }
+
+    /**
+     * Get the identifier for the filter.
+     *
+     * @return string Filter identifier.
+     */
+    protected static function get_identifier(): string {
+        return 'filter' . static::get_name();
+    }
+
+    /**
+     * Get a language string for the filter.
+     *
+     * @param string $identifier Sub-identifier for the language string. E.g. 'name', 'summary', etc.
+     * @return string Language string.
+     * @throws coding_exception
+     */
+    protected static function get_string(string $identifier): string {
+        return get_string(
+            static::get_identifier() . "_$identifier",
+            'block_configurable_reports'
+        );
+    }
+
+    /**
+     * Get submitted filter form values.
+     *
+     * @return int[] Filter form values.
+     * @throws coding_exception
+     */
+    protected static function get_form_value(): array {
+        // Workaround to ignore empty autocomplete field since we don't have form data.
+        $raw_value = $_POST[static::get_identifier()] ?? $_GET[static::get_identifier()] ?? null;
+        if (
+            !$raw_value ||
+            $raw_value === '_qf__force_multiselect_submission'
+        ) {
+            return [];
+        }
+
+        return optional_param_array(static::get_identifier(), [], PARAM_INT);
+    }
+
+    /**
+     * Add a general hierarchy level selector to a given form.
+     *
+     * @param MoodleQuickForm $mform Form to add the selector to.
+     * @param string $hierarchy_idnumber Target hierarchy ID number.
+     * @return void
+     * @throws coding_exception
+     */
+    protected static function add_level_selector(MoodleQuickForm $mform, string $hierarchy_idnumber): void {
+        $hierarchy = hierarchy::get_record([ 'idnumber' => $hierarchy_idnumber ]);
+        if (!$hierarchy) {
+            $mform->addElement(
+                'static',
+                static::get_identifier(),
+                static::get_string('name'),
+                static::get_string('nohierarchy')
+            );
+
+            return;
+        }
+
+        $levels = level::get_records(
+            [ 'hierarchyid' => $hierarchy->get('id') ],
+            'name'
+        );
+        if (empty($levels)) {
+            $mform->addElement(
+                'static',
+                static::get_identifier(),
+                static::get_string('name'),
+                static::get_string('nolevels')
+            );
+
+            return;
+        }
+
+        $level_options = [];
+        foreach ($levels as $level) {
+            $level_options[$level->get('id')] = $level->get('name') . ' (' . $level->get('idnumber') . ')';
+        }
+
+        $mform->addElement(
+            'autocomplete',
+            static::get_identifier(),
+            static::get_string('name'),
+            $level_options,
+            [ 'multiple' => true ]
+        );
+    }
+}

--- a/components/filters/orgcostcentre/plugin.class.php
+++ b/components/filters/orgcostcentre/plugin.class.php
@@ -1,0 +1,30 @@
+<?php
+
+use block_configurable_reports\local\plugin\org_filter_base;
+
+/** @noinspection PhpUnused */
+class plugin_orgcostcentre extends org_filter_base {
+
+    /**
+     * @inheritDoc
+     */
+    public function init(): void {
+        parent::init();
+
+        $this->reporttypes = [ 'sql', 'users' ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function get_name(): string {
+        return 'orgcostcentre';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
+        parent::add_level_selector($mform, 'costcentre');
+    }
+}

--- a/components/filters/orgdivision/plugin.class.php
+++ b/components/filters/orgdivision/plugin.class.php
@@ -25,6 +25,6 @@ class plugin_orgdivision extends org_filter_base {
      * @inheritDoc
      */
     public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
-        parent::add_level_selector($mform, 'paypoint', 1);
+        parent::add_level_selector($mform, 'paypoint', 1, true);
     }
 }

--- a/components/filters/orgdivision/plugin.class.php
+++ b/components/filters/orgdivision/plugin.class.php
@@ -1,0 +1,30 @@
+<?php
+
+use block_configurable_reports\local\plugin\org_filter_base;
+
+/** @noinspection PhpUnused */
+class plugin_orgdivision extends org_filter_base {
+
+    /**
+     * @inheritDoc
+     */
+    public function init(): void {
+        parent::init();
+
+        $this->reporttypes = [ 'sql', 'users' ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function get_name(): string {
+        return 'orgdivision';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
+        parent::add_level_selector($mform, 'paypoint', 1);
+    }
+}

--- a/components/filters/orgemptype/plugin.class.php
+++ b/components/filters/orgemptype/plugin.class.php
@@ -1,0 +1,30 @@
+<?php
+
+use block_configurable_reports\local\plugin\org_filter_base;
+
+/** @noinspection PhpUnused */
+class plugin_orgemptype extends org_filter_base {
+
+    /**
+     * @inheritDoc
+     */
+    public function init(): void {
+        parent::init();
+
+        $this->reporttypes = [ 'sql', 'users' ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function get_name(): string {
+        return 'orgemptype';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
+        parent::add_level_selector($mform, 'emptype');
+    }
+}

--- a/components/filters/orgfacility/plugin.class.php
+++ b/components/filters/orgfacility/plugin.class.php
@@ -3,7 +3,7 @@
 use block_configurable_reports\local\plugin\org_filter_base;
 
 /** @noinspection PhpUnused */
-class plugin_orgunit extends org_filter_base {
+class plugin_orgfacility extends org_filter_base {
 
     /**
      * @inheritDoc
@@ -18,13 +18,13 @@ class plugin_orgunit extends org_filter_base {
      * @inheritDoc
      */
     protected static function get_name(): string {
-        return 'orgunit';
+        return 'orgfacility';
     }
 
     /**
      * @inheritDoc
      */
     public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
-        static::add_level_selector($mform, 'unit');
+        parent::add_level_selector($mform, 'facility');
     }
 }

--- a/components/filters/orgjobcode/plugin.class.php
+++ b/components/filters/orgjobcode/plugin.class.php
@@ -1,0 +1,30 @@
+<?php
+
+use block_configurable_reports\local\plugin\org_filter_base;
+
+/** @noinspection PhpUnused */
+class plugin_orgjobcode extends org_filter_base {
+
+    /**
+     * @inheritDoc
+     */
+    public function init(): void {
+        parent::init();
+
+        $this->reporttypes = [ 'sql', 'users' ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function get_name(): string {
+        return 'orgjobcode';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
+        parent::add_level_selector($mform, 'jobcode');
+    }
+}

--- a/components/filters/orgpaypoint/plugin.class.php
+++ b/components/filters/orgpaypoint/plugin.class.php
@@ -1,0 +1,30 @@
+<?php
+
+use block_configurable_reports\local\plugin\org_filter_base;
+
+/** @noinspection PhpUnused */
+class plugin_orgpaypoint extends org_filter_base {
+
+    /**
+     * @inheritDoc
+     */
+    public function init(): void {
+        parent::init();
+
+        $this->reporttypes = [ 'sql', 'users' ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function get_name(): string {
+        return 'orgpaypoint';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
+        parent::add_level_selector($mform, 'paypoint');
+    }
+}

--- a/components/filters/orgstream/plugin.class.php
+++ b/components/filters/orgstream/plugin.class.php
@@ -1,0 +1,30 @@
+<?php
+
+use block_configurable_reports\local\plugin\org_filter_base;
+
+/** @noinspection PhpUnused */
+class plugin_orgstream extends org_filter_base {
+
+    /**
+     * @inheritDoc
+     */
+    public function init(): void {
+        parent::init();
+
+        $this->reporttypes = [ 'sql', 'users' ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function get_name(): string {
+        return 'orgstream';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
+        parent::add_level_selector($mform, 'costcentre', 4);
+    }
+}

--- a/components/filters/orgstream/plugin.class.php
+++ b/components/filters/orgstream/plugin.class.php
@@ -25,6 +25,6 @@ class plugin_orgstream extends org_filter_base {
      * @inheritDoc
      */
     public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
-        parent::add_level_selector($mform, 'costcentre', 4);
+        parent::add_level_selector($mform, 'costcentre', 4, true);
     }
 }

--- a/components/filters/orgunit/plugin.class.php
+++ b/components/filters/orgunit/plugin.class.php
@@ -1,0 +1,181 @@
+<?php
+
+global $CFG;
+
+use tool_organisation\persistent\hierarchy;
+use tool_organisation\persistent\level;
+
+require_once($CFG->dirroot.'/blocks/configurable_reports/plugin.class.php');
+
+/** @noinspection PhpUnused */
+class plugin_orgunit extends plugin_base {
+
+    /**
+     * Initialise filter.
+     *
+     * @return void
+     * @throws coding_exception
+     */
+    public function init(): void {
+        $this->form = false;
+        $this->unique = true;
+        $this->fullname = get_string('filterorgunit', 'block_configurable_reports');
+        $this->reporttypes = [ 'sql', 'users' ];
+    }
+
+    /**
+     * Get summary of the filter.
+     *
+     * @param stdClass $data Filter data.
+     * @return string Summary of the filter.
+     * @throws coding_exception
+     */
+    public function summary($data): string {
+        return get_string('filterorgunit_summary', 'block_configurable_reports');
+    }
+
+    /**
+     * Execute the filter.
+     *
+     * @param array|string $final_elements Content to be filtered.
+     * @param stdClass $data Filter data
+     * @return array|string Filtered content.
+     * @throws coding_exception
+     * @throws dml_exception
+     */
+    public function execute($final_elements, stdClass $data) {
+        $filter_value = self::get_form_value();
+        if (empty($filter_value)) {
+            return $final_elements;
+        }
+
+        if ($this->report->type === 'sql') {
+            return self::execute_sql($final_elements, $data, $filter_value);
+        }
+
+        return self::execute_users($final_elements, $data, $filter_value);
+    }
+
+    /**
+     * Output filter fields to report form.
+     *
+     * @param MoodleQuickForm $mform Report form.
+     * @param stdClass $data Filter data.
+     * @return void
+     * @throws coding_exception
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function print_filter(MoodleQuickForm $mform, stdClass $data): void {
+        $hierarchy = hierarchy::get_record([ 'idnumber' => 'unit' ]);
+        if (!$hierarchy) {
+            $mform->addElement('static', 'filter_orgunit', '', get_string('filterorgunit_nohierarchy', 'block_configurable_reports'));
+
+            return;
+        }
+
+        $levels = level::get_records(
+            [ 'hierarchyid' => $hierarchy->get('id') ],
+            'name'
+        );
+        if (empty($levels)) {
+            $mform->addElement('static', 'filter_orgunit', '', get_string('filterorgunit_nolevels', 'block_configurable_reports'));
+
+            return;
+        }
+
+        $level_options = [];
+        foreach ($levels as $level) {
+            $level_options[$level->get('id')] = $level->get('name') . ' (' . $level->get('idnumber') . ')';
+        }
+
+        $mform->addElement(
+            'autocomplete',
+            'filter_orgunit',
+            get_string('filterorgunit', 'block_configurable_reports'),
+            $level_options,
+            [ 'multiple' => true ]
+        );
+    }
+
+    /**
+     * Get submitted filter form values.
+     *
+     * @return int[] Filter form values.
+     * @throws coding_exception
+     */
+    private static function get_form_value(): array {
+        // Workaround to ignore empty autocomplete field since we don't have form data.
+        $raw_value = $_POST['filter_orgunit'] ?? $_GET['filter_orgunit'] ?? null;
+        if (
+            !$raw_value ||
+            $raw_value === '_qf__force_multiselect_submission'
+        ) {
+            return [];
+        }
+
+        return optional_param_array('filter_orgunit', [], PARAM_INT);
+    }
+
+    /**
+     * Execute filter for SQL reports.
+     *
+     * @param string $final_elements Content to be filtered.
+     * @param stdClass $data Filter data.
+     * @param int[] $filter_value Filter values.
+     * @return string Filtered content.
+     * @noinspection PhpUnusedParameterInspection
+     */
+    private static function execute_sql(string $final_elements, stdClass $data, array $filter_value): string {
+        preg_match("/%%FILTER_ORGUNIT:([^%]+)%%/i", $final_elements, $matches);
+        if ($matches) {
+            $values = implode(',', $filter_value);
+            $replace = " AND $matches[1] IN ($values)";
+
+            return str_replace(
+                "%%FILTER_ORGUNIT:$matches[1]%%",
+                $replace,
+                $final_elements
+            );
+        }
+
+        return $final_elements;
+    }
+
+    /**
+     * Execute filter for user reports.
+     *
+     * @param int[] $final_elements Content to be filtered.
+     * @param stdClass $data Filter data.
+     * @param int[] $filter_value Filter values.
+     * @return int[] Filtered content.
+     * @throws coding_exception
+     * @throws dml_exception
+     * @noinspection PhpUnusedParameterInspection
+     */
+    private static function execute_users(array $final_elements, stdClass $data, array $filter_value): array {
+        global $DB;
+
+        [ $user_sql, $user_params ] = $DB->get_in_or_equal($final_elements);
+        [ $level_sql, $level_params ] = $DB->get_in_or_equal($filter_value);
+
+        return $DB->get_fieldset_sql(
+            "
+                select  users.id
+                from    {user} users
+                        join {tool_organisation_assign} assignments on
+                            assignments.userid = users.id
+                        join {tool_organisation_positions} positions on
+                            positions.id = assignments.positionid
+                        join {tool_organisation_level_data} level_data on
+                            level_data.positionid = positions.id or
+                            level_data.assignid = assignments.id
+                where   users.id $user_sql and
+                        level_data.levelid $level_sql
+            ",
+            array_merge(
+                $user_params,
+                $level_params,
+            )
+        );
+    }
+}

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -18,7 +18,7 @@
 $string['orgcostcentre'] = 'Organisation Cost Centre';
 $string['filterorgcostcentre_name'] = 'Filter organisation cost centres';
 $string['filterorgcostcentre_summary'] = "
-Filter by Organisation Division<br>
+Filter by Organisation Cost Centre<br>
 Use '%%FILTER_ORGCOSTCENTRE:table.path%%'
 ";
 $string['filterorgcostcentre_nohierarchy'] = 'Paypoint hierarchy not found';
@@ -58,7 +58,7 @@ $string['filterorgpaypoint_nolevels'] = 'No paypoints found';
 $string['orgstream'] = 'Organisation Stream';
 $string['filterorgstream_name'] = 'Filter organisation streams';
 $string['filterorgstream_summary'] = "
-Filter by Organisation Division<br>
+Filter by Organisation Stream<br>
 Use '%%FILTER_ORGSTREAM:table.path%%'
 ";
 $string['filterorgstream_nohierarchy'] = 'Cost Centre hierarchy not found';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -23,14 +23,6 @@ Use '%%FILTER_ORGDIVISION:table.path%%'
 ";
 $string['filterorgdivision_nohierarchy'] = 'Paypoint hierarchy not found';
 $string['filterorgdivision_nolevels'] = 'No divisions found';
-$string['orgunit'] = 'Organisation Unit';
-$string['filterorgunit_name'] = 'Filter organisation units';
-$string['filterorgunit_summary'] = "
-Filter by Organisation Unit<br>
-Use '%%FILTER_ORGUNIT:table.path%%'
-";
-$string['filterorgunit_nohierarchy'] = 'Unit hierarchy not found';
-$string['filterorgunit_nolevels'] = 'No units found';
 $string['orgfacility'] = 'Organisation Facility';
 $string['filterorgfacility_name'] = 'Filter organisation facilities';
 $string['filterorgfacility_summary'] = "
@@ -47,6 +39,14 @@ Use '%%FILTER_ORGJOBCODE:table.path%%'
 ";
 $string['filterorgjobcode_nohierarchy'] = 'Job Code hierarchy not found';
 $string['filterorgjobcode_nolevels'] = 'No job codes found';
+$string['orgunit'] = 'Organisation Unit';
+$string['filterorgunit_name'] = 'Filter organisation units';
+$string['filterorgunit_summary'] = "
+Filter by Organisation Unit<br>
+Use '%%FILTER_ORGUNIT:table.path%%'
+";
+$string['filterorgunit_nohierarchy'] = 'Unit hierarchy not found';
+$string['filterorgunit_nolevels'] = 'No units found';
 $string['fsearchsession'] = 'Face to Face Search Session ID';
 $string['fsearchuser'] = 'Search User Name Details';
 $string['division'] = 'Filter by Division';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -31,6 +31,14 @@ Use '%%FILTER_ORGFACILITY:table.path%%'
 ";
 $string['filterorgfacility_nohierarchy'] = 'Facility hierarchy not found';
 $string['filterorgfacility_nolevels'] = 'No facilities found';
+$string['orgjobcode'] = 'Organisation Job Code';
+$string['filterorgjobcode_name'] = 'Filter organisation job codes';
+$string['filterorgjobcode_summary'] = "
+Filter by Organisation Job Code<br>
+Use '%%FILTER_ORGJOBCODE:table.path%%'
+";
+$string['filterorgjobcode_nohierarchy'] = 'Job Code hierarchy not found';
+$string['filterorgjobcode_nolevels'] = 'No job codes found';
 $string['fsearchsession'] = 'Face to Face Search Session ID';
 $string['fsearchuser'] = 'Search User Name Details';
 $string['division'] = 'Filter by Division';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -21,6 +21,7 @@ $string['filterorgcostcentre_summary'] = "
 Filter by Organisation Cost Centre<br>
 Use '%%FILTER_ORGCOSTCENTRE:table.path%%'
 ";
+$string['filterorgcostcentre_includechildren'] = 'Include child cost centres';
 $string['filterorgcostcentre_nohierarchy'] = 'Paypoint hierarchy not found';
 $string['filterorgcostcentre_nolevels'] = 'No cost centres found';
 $string['orgdivision'] = 'Organisation Division';
@@ -37,6 +38,7 @@ $string['filterorgemptype_summary'] = "
 Filter by Organisation Employee Type<br>
 Use '%%FILTER_ORGEMPTYPE:table.path%%'
 ";
+$string['filterorgemptype_includechildren'] = 'Include child employee types';
 $string['filterorgemptype_nohierarchy'] = 'Employee Type hierarchy not found';
 $string['filterorgemptype_nolevels'] = 'No employee types found';
 $string['orgfacility'] = 'Organisation Facility';
@@ -45,6 +47,7 @@ $string['filterorgfacility_summary'] = "
 Filter by Organisation Facility<br>
 Use '%%FILTER_ORGFACILITY:table.path%%'
 ";
+$string['filterorgfacility_includechildren'] = 'Include child facilities';
 $string['filterorgfacility_nohierarchy'] = 'Facility hierarchy not found';
 $string['filterorgfacility_nolevels'] = 'No facilities found';
 $string['orgjobcode'] = 'Organisation Job Code';
@@ -53,6 +56,7 @@ $string['filterorgjobcode_summary'] = "
 Filter by Organisation Job Code<br>
 Use '%%FILTER_ORGJOBCODE:table.path%%'
 ";
+$string['filterorgjobcode_includechildren'] = 'Include child job codes';
 $string['filterorgjobcode_nohierarchy'] = 'Job Code hierarchy not found';
 $string['filterorgjobcode_nolevels'] = 'No job codes found';
 $string['orgpaypoint'] = 'Organisation Paypoint';
@@ -61,6 +65,7 @@ $string['filterorgpaypoint_summary'] = "
 Filter by Organisation Paypoint<br>
 Use '%%FILTER_ORGPAYPOINT:table.path%%'
 ";
+$string['filterorgpaypoint_includechildren'] = 'Include child paypoints';
 $string['filterorgpaypoint_nohierarchy'] = 'Paypoint hierarchy not found';
 $string['filterorgpaypoint_nolevels'] = 'No paypoints found';
 $string['orgstream'] = 'Organisation Stream';
@@ -77,6 +82,7 @@ $string['filterorgunit_summary'] = "
 Filter by Organisation Unit<br>
 Use '%%FILTER_ORGUNIT:table.path%%'
 ";
+$string['filterorgunit_includechildren'] = 'Include child units';
 $string['filterorgunit_nohierarchy'] = 'Unit hierarchy not found';
 $string['filterorgunit_nolevels'] = 'No units found';
 $string['fsearchsession'] = 'Face to Face Search Session ID';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -15,6 +15,14 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 // GCHLOL
+$string['orgdivision'] = 'Organisation Division';
+$string['filterorgdivision_name'] = 'Filter organisation divisions';
+$string['filterorgdivision_summary'] = "
+Filter by Organisation Division<br>
+Use '%%FILTER_ORGDIVISION:table.path%%'
+";
+$string['filterorgdivision_nohierarchy'] = 'Paypoint hierarchy not found';
+$string['filterorgdivision_nolevels'] = 'No divisions found';
 $string['orgunit'] = 'Organisation Unit';
 $string['filterorgunit_name'] = 'Filter organisation units';
 $string['filterorgunit_summary'] = "

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -15,6 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 // GCHLOL
+$string['orgunit'] = 'Organisation Unit';
+$string['filterorgunit'] = 'Filter organisation units';
+$string['filterorgunit_summary'] = 'Filter by Organisation Unit';
+$string['filterorgunit_nohierarchy'] = 'Unit hierarchy not found';
+$string['filterorgunit_nolevels'] = 'No units found';
 $string['fsearchsession'] = 'Face to Face Search Session ID';
 $string['fsearchuser'] = 'Search User Name Details';
 $string['division'] = 'Filter by Division';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -16,10 +16,15 @@
 
 // GCHLOL
 $string['orgunit'] = 'Organisation Unit';
-$string['filterorgunit'] = 'Filter organisation units';
+$string['filterorgunit_name'] = 'Filter organisation units';
 $string['filterorgunit_summary'] = 'Filter by Organisation Unit';
 $string['filterorgunit_nohierarchy'] = 'Unit hierarchy not found';
 $string['filterorgunit_nolevels'] = 'No units found';
+$string['orgfacility'] = 'Organisation Facility';
+$string['filterorgfacility_name'] = 'Filter organisation facilities';
+$string['filterorgfacility_summary'] = 'Filter by Organisation Facility';
+$string['filterorgfacility_nohierarchy'] = 'Facility hierarchy not found';
+$string['filterorgfacility_nolevels'] = 'No facilities found';
 $string['fsearchsession'] = 'Face to Face Search Session ID';
 $string['fsearchuser'] = 'Search User Name Details';
 $string['division'] = 'Filter by Division';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -47,6 +47,14 @@ Use '%%FILTER_ORGJOBCODE:table.path%%'
 ";
 $string['filterorgjobcode_nohierarchy'] = 'Job Code hierarchy not found';
 $string['filterorgjobcode_nolevels'] = 'No job codes found';
+$string['orgpaypoint'] = 'Organisation Paypoint';
+$string['filterorgpaypoint_name'] = 'Filter organisation paypoints';
+$string['filterorgpaypoint_summary'] = "
+Filter by Organisation Paypoint<br>
+Use '%%FILTER_ORGPAYPOINT:table.path%%'
+";
+$string['filterorgpaypoint_nohierarchy'] = 'Paypoint hierarchy not found';
+$string['filterorgpaypoint_nolevels'] = 'No paypoints found';
 $string['orgstream'] = 'Organisation Stream';
 $string['filterorgstream_name'] = 'Filter organisation streams';
 $string['filterorgstream_summary'] = "

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -17,12 +17,18 @@
 // GCHLOL
 $string['orgunit'] = 'Organisation Unit';
 $string['filterorgunit_name'] = 'Filter organisation units';
-$string['filterorgunit_summary'] = 'Filter by Organisation Unit';
+$string['filterorgunit_summary'] = "
+Filter by Organisation Unit<br>
+Use '%%FILTER_ORGUNIT:table.path%%'
+";
 $string['filterorgunit_nohierarchy'] = 'Unit hierarchy not found';
 $string['filterorgunit_nolevels'] = 'No units found';
 $string['orgfacility'] = 'Organisation Facility';
 $string['filterorgfacility_name'] = 'Filter organisation facilities';
-$string['filterorgfacility_summary'] = 'Filter by Organisation Facility';
+$string['filterorgfacility_summary'] = "
+Filter by Organisation Facility<br>
+Use '%%FILTER_ORGFACILITY:table.path%%'
+";
 $string['filterorgfacility_nohierarchy'] = 'Facility hierarchy not found';
 $string['filterorgfacility_nolevels'] = 'No facilities found';
 $string['fsearchsession'] = 'Face to Face Search Session ID';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -15,6 +15,14 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 // GCHLOL
+$string['orgcostcentre'] = 'Organisation Cost Centre';
+$string['filterorgcostcentre_name'] = 'Filter organisation cost centres';
+$string['filterorgcostcentre_summary'] = "
+Filter by Organisation Division<br>
+Use '%%FILTER_ORGCOSTCENTRE:table.path%%'
+";
+$string['filterorgcostcentre_nohierarchy'] = 'Paypoint hierarchy not found';
+$string['filterorgcostcentre_nolevels'] = 'No cost centres found';
 $string['orgdivision'] = 'Organisation Division';
 $string['filterorgdivision_name'] = 'Filter organisation divisions';
 $string['filterorgdivision_summary'] = "

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -47,6 +47,14 @@ Use '%%FILTER_ORGJOBCODE:table.path%%'
 ";
 $string['filterorgjobcode_nohierarchy'] = 'Job Code hierarchy not found';
 $string['filterorgjobcode_nolevels'] = 'No job codes found';
+$string['orgstream'] = 'Organisation Stream';
+$string['filterorgstream_name'] = 'Filter organisation streams';
+$string['filterorgstream_summary'] = "
+Filter by Organisation Division<br>
+Use '%%FILTER_ORGSTREAM:table.path%%'
+";
+$string['filterorgstream_nohierarchy'] = 'Cost Centre hierarchy not found';
+$string['filterorgstream_nolevels'] = 'No streams found';
 $string['orgunit'] = 'Organisation Unit';
 $string['filterorgunit_name'] = 'Filter organisation units';
 $string['filterorgunit_summary'] = "

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -31,6 +31,14 @@ Use '%%FILTER_ORGDIVISION:table.path%%'
 ";
 $string['filterorgdivision_nohierarchy'] = 'Paypoint hierarchy not found';
 $string['filterorgdivision_nolevels'] = 'No divisions found';
+$string['orgemptype'] = 'Organisation Employee Type';
+$string['filterorgemptype_name'] = 'Filter organisation employee type';
+$string['filterorgemptype_summary'] = "
+Filter by Organisation Employee Type<br>
+Use '%%FILTER_ORGEMPTYPE:table.path%%'
+";
+$string['filterorgemptype_nohierarchy'] = 'Employee Type hierarchy not found';
+$string['filterorgemptype_nolevels'] = 'No employee types found';
 $string['orgfacility'] = 'Organisation Facility';
 $string['filterorgfacility_name'] = 'Filter organisation facilities';
 $string['filterorgfacility_summary'] = "

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023100400;  // Plugin version.
+$plugin->version = 2023100401;  // Plugin version.
 $plugin->requires = 2017111300; // require Moodle version (3.4).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '3.9.0';

--- a/version.php
+++ b/version.php
@@ -36,3 +36,7 @@ $plugin->release = '3.9.0';
 $plugin->component = 'block_configurable_reports'; // Full name of the plugin (used for diagnostics)
 $plugin->cron      = 86400; // = Once in 24h, Set min time between cron executions.
                             // Should probably be at night to off load CPU load.
+
+$plugin->dependencies = [
+    'tool_organisation' => 2024061700,
+];


### PR DESCRIPTION
Adds the following hierarchy related filters:
1. Facility
2. Job Code
3. Division
4. Cost Centre
5. Stream
6. Paypoint
7. Employee Type

These filters have an option to include child levels other than Division and Stream which always include them due to their specialised targetting.