### PR TITLE
GS-737: Organisation filters not checking include_children from URL param

### DIFF
--- a/classes/local/plugin/org_filter_base.php
+++ b/classes/local/plugin/org_filter_base.php
@@ -297,6 +297,11 @@ abstract class org_filter_base extends plugin_base {
             '',
             static::get_string('includechildren')
         );
+
+        $include_children_param = optional_param($include_children_identifier, 0, PARAM_BOOL);
+        if ($include_children_param) {
+            $mform->setDefault($include_children_identifier, 1);
+        }
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023100401;  // Plugin version.
+$plugin->version = 2025041000;  // Plugin version.
 $plugin->requires = 2017111300; // require Moodle version (3.4).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '3.9.0';


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Checkbox is ticked when URL param includes children (e.g. filterorgunit_include_children=1)

## Checklist before requesting a review:
- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.
- [x] Any new test cases have been created and existing test cases updated (excluding epic sub-issues).
