### PR TITLE
GS-738 Git Snippets Incorrect Reports Dropdown Values

### DIFF
--- a/components/customsql/form.php
+++ b/components/customsql/form.php
@@ -58,7 +58,7 @@ class customsql_form extends moodleform {
             $res = json_decode($res);
 
             if (is_array($res)) {
-                $reportcategories = array(get_string('choose'));
+                $reportcategories = ['' => get_string('choose')];
                 foreach ($res as $item) {
                     if ($item->type == 'dir') {
                         $reportcategories[$item->path] = $item->path;
@@ -71,7 +71,7 @@ class customsql_form extends moodleform {
 
                 $reportsincatstr = get_string('reportsincategory', 'block_configurable_reports');
                 $reportsincatattrs = ['onchange' => 'M.block_configurable_reports.onchange_reportsincategory(this,"'.sesskey().'")'];
-                $mform->addElement('select', 'reportsincategory', $reportsincatstr, $reportcategories, $reportsincatattrs);
+                $mform->addElement('select', 'reportsincategory', $reportsincatstr, ['' => get_string('choose')], $reportsincatattrs);
 
                 $mform->addElement('textarea', 'remotequerysql', get_string('remotequerysql', 'block_configurable_reports'),
                     'rows="15" cols="90"');

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -520,7 +520,7 @@ $string['totalrecords'] = 'Total record count = {$a->totalrecords}';
 $string['lastexecutiontime'] = 'Execution time = {$a} (Sec)';
 
 $string['reportcategories'] = '1) Choose a remote report categories';
-$string['reportsincategory'] = '2) Choose a report form the list';
+$string['reportsincategory'] = '2) Choose a report from the list';
 $string['remotequerysql'] = 'SQL query';
 $string['executeat'] = 'Execute at';
 $string['executeatinfo'] = 'Moodle CRON will run scheduled SQL queries after selected time. Once in 24h';

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025041000;  // Plugin version.
+$plugin->version = 2025041001;  // Plugin version.
 $plugin->requires = 2017111300; // require Moodle version (3.4).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '3.9.0';


### PR DESCRIPTION
## Description:

This update fixes a form issue in the block_configurable_reports plugin where the "Reports in Category" dropdown was not behaving as expected.

Key issues addressed:

- The dropdown was initialised using array(get_string('choose')), which created a numerically indexed array.

As a result, the placeholder "Choose" option had a key of 0 instead of an empty string (''), leading to:

- The default selection not being recognised properly,

- Difficulty distinguishing between a placeholder and a valid selection.

Updated Language string for $string['reportsincategory'] = '2) Choose a report form the list' to 2) Choose a report from the list'.

Fix implemented:

- Updated the default options array to use ['' => get_string('choose')], assigning the label to an empty string key.

- Ensured that the corrected $reportcategories array is passed directly to $mform->addElement().

Benefits of this change:

- Ensures the "Choose" option behaves as a proper placeholder in the dropdown.

- Makes the selection logic more consistent and predictable for end users.

- Prevents confusion or misinterpretation when no category has been selected.


## Checklist before requesting a review:

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have been updated.
