### PR TITLE
GS-739 Don't Add date to Imported Report Names

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -506,7 +506,6 @@ function cr_import_xml($xml, $course) {
         }
         $newreport->courseid = $course->id;
         $newreport->ownerid = $USER->id;
-        $newreport->name .= " (" . userdate(time()) . ")";
 
         if (!$DB->insert_record('block_configurable_reports', $newreport)) {
             return false;

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025041001;  // Plugin version.
+$plugin->version = 2025041002;  // Plugin version.
 $plugin->requires = 2017111300; // require Moodle version (3.4).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '3.9.0';


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->

When a report is exported and re-imported using the Configurable Reports plugin, the current date is automatically appended to the report name. To improve the user experience and reduce the need for manual cleanup, this pull request removes that automatic date insertion.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have been updated.
