### PR TITLE
[Hotfix] GS-1424 Configurable Report shall log both before and after a report is run

### DIFF
--- a/classes/event/report_run_started.php
+++ b/classes/event/report_run_started.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-// GCHLOL: Define the report event that logs execution before the report query starts.
 namespace block_configurable_reports\event;
 
 use coding_exception;
@@ -111,4 +110,3 @@ class report_run_started extends base {
         return new moodle_url('/blocks/configurable_reports/viewreport.php', ['id' => $this->objectid]);
     }
 }
-// GCHLOL ends.

--- a/classes/event/report_run_started.php
+++ b/classes/event/report_run_started.php
@@ -30,10 +30,10 @@ use stdClass;
  * crashes the site while running (for example an excessively large report)
  * remains traceable even though it never finishes and shows its output.
  *
- * @package     block_configurable_reports
- * @copyright   2026 Gold Coast Health
- * @author      Yucheng Zhu
- * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    block_configurable_reports
+ * @copyright  2026 Gold Coast Health
+ * @author     Yucheng Zhu
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class report_run_started extends base {
     /**

--- a/classes/event/report_run_started.php
+++ b/classes/event/report_run_started.php
@@ -37,9 +37,9 @@ use stdClass;
  */
 class report_run_started extends base {
     /**
-     * Init event data.
+     * Initialises the event metadata for a report run start event.
      *
-     * @return void
+     * @return void Sets the CRUD action, education level, and source table for the event.
      */
     protected function init(): void {
         $this->data['crud'] = 'r';
@@ -48,11 +48,11 @@ class report_run_started extends base {
     }
 
     /**
-     * Build event from a report record.
+     * Creates a report run started event from a report record.
      *
-     * @param context $context
-     * @param stdClass $report
-     * @return static
+     * @param context $context The context where the report is being run.
+     * @param stdClass $report The report record containing the report ID and name.
+     * @return static The created report run started event instance.
      */
     public static function create_from_report(context $context, stdClass $report): base {
         return static::create([
@@ -65,18 +65,18 @@ class report_run_started extends base {
     }
 
     /**
-     * Returns localized event name.
+     * Gets the localised name of the event.
      *
-     * @return string
+     * @return string The localised event name.
      */
     public static function get_name(): string {
         return get_string('event:reportrunstarted', 'block_configurable_reports');
     }
 
     /**
-     * Describes event.
+     * Gets the localised description of the started report run event.
      *
-     * @return string
+     * @return string The localised event description.
      */
     public function get_description(): string {
         $data = new stdClass();
@@ -87,9 +87,10 @@ class report_run_started extends base {
     }
 
     /**
-     * Validate required data.
+     * Validates that the event contains the required report data.
      *
-     * @return void
+     * @return void Validates the event data before the event is triggered.
+     * @throws coding_exception If the report ID or report name is missing from the event data.
      */
     protected function validate_data(): void {
         parent::validate_data();
@@ -102,9 +103,9 @@ class report_run_started extends base {
     }
 
     /**
-     * Returns URL related to event context.
+     * Gets the report URL related to the event.
      *
-     * @return moodle_url
+     * @return moodle_url The URL of the report view page for this event.
      */
     public function get_url(): moodle_url {
         return new moodle_url('/blocks/configurable_reports/viewreport.php', ['id' => $this->objectid]);

--- a/classes/event/report_run_started.php
+++ b/classes/event/report_run_started.php
@@ -1,0 +1,111 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace block_configurable_reports\event;
+
+use coding_exception;
+use context;
+use core\event\base;
+use moodle_url;
+use stdClass;
+
+/**
+ * Event triggered before a configurable report is run.
+ *
+ * This is logged before the report query executes, so that a report which
+ * crashes the site while running (for example an excessively large report)
+ * remains traceable even though it never finishes and shows its output.
+ *
+ * @package     block_configurable_reports
+ * @copyright   2026 Gold Coast Health
+ * @author      Yucheng Zhu
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class report_run_started extends base {
+    /**
+     * Init event data.
+     *
+     * @return void
+     */
+    protected function init(): void {
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = static::LEVEL_PARTICIPATING;
+        $this->data['objecttable'] = 'block_configurable_reports';
+    }
+
+    /**
+     * Build event from a report record.
+     *
+     * @param context $context
+     * @param stdClass $report
+     * @return static
+     */
+    public static function create_from_report(context $context, stdClass $report): base {
+        return static::create([
+            'context' => $context,
+            'objectid' => $report->id,
+            'other' => [
+                'reportname' => format_string($report->name),
+            ],
+        ]);
+    }
+
+    /**
+     * Returns localized event name.
+     *
+     * @return string
+     */
+    public static function get_name(): string {
+        return get_string('event:reportrunstarted', 'block_configurable_reports');
+    }
+
+    /**
+     * Describes event.
+     *
+     * @return string
+     */
+    public function get_description(): string {
+        $data = new stdClass();
+        $data->userid = $this->userid;
+        $data->reportname = $this->other['reportname'];
+        $data->objectid = $this->objectid;
+        return get_string('event:reportrunstarted:desc', 'block_configurable_reports', $data);
+    }
+
+    /**
+     * Validate required data.
+     *
+     * @return void
+     */
+    protected function validate_data(): void {
+        parent::validate_data();
+        if (!isset($this->objectid)) {
+            throw new coding_exception('The \'objectid\' must be set.');
+        }
+        if (!isset($this->other['reportname'])) {
+            throw new coding_exception('The \'reportname\' must be set in other.');
+        }
+    }
+
+    /**
+     * Returns URL related to event context.
+     *
+     * @return moodle_url
+     */
+    public function get_url(): moodle_url {
+        return new moodle_url('/blocks/configurable_reports/viewreport.php', ['id' => $this->objectid]);
+    }
+}

--- a/classes/event/report_run_started.php
+++ b/classes/event/report_run_started.php
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+// GCHLOL: Define the report event that logs execution before the report query starts.
 namespace block_configurable_reports\event;
 
 use coding_exception;
@@ -109,3 +110,4 @@ class report_run_started extends base {
         return new moodle_url('/blocks/configurable_reports/viewreport.php', ['id' => $this->objectid]);
     }
 }
+// GCHLOL ends.

--- a/classes/local/util/event_util.php
+++ b/classes/local/util/event_util.php
@@ -16,7 +16,6 @@
 
 namespace block_configurable_reports\local\util;
 
-use block_configurable_reports\event\report_run_started;
 use block_configurable_reports\event\report_updated;
 use context;
 use context_course;
@@ -32,17 +31,6 @@ use stdClass;
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class event_util {
-
-    /**
-     * Log report execution start.
-     *
-     * @param context $context
-     * @param stdClass $report
-     * @return void
-     */
-    public static function log_report_run_started(context $context, stdClass $report): void {
-        report_run_started::create_from_report($context, $report)->trigger();
-    }
 
     /**
      * Log visibility change as report update.

--- a/classes/local/util/event_util.php
+++ b/classes/local/util/event_util.php
@@ -16,6 +16,7 @@
 
 namespace block_configurable_reports\local\util;
 
+use block_configurable_reports\event\report_run_started;
 use block_configurable_reports\event\report_updated;
 use context;
 use context_course;
@@ -31,6 +32,17 @@ use stdClass;
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class event_util {
+
+    /**
+     * Log report execution start.
+     *
+     * @param context $context
+     * @param stdClass $report
+     * @return void
+     */
+    public static function log_report_run_started(context $context, stdClass $report): void {
+        report_run_started::create_from_report($context, $report)->trigger();
+    }
 
     /**
      * Log visibility change as report update.

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -666,10 +666,8 @@ $string['repositorytoken'] = 'GitHub Access Token';
 $string['repositorytokeninfo'] = 'Optional access token to include with each request. This token requires the Contents Read-only permission at a minimum. See <a target="_blank" href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens">Personal Access Token Docs</a>.';
 
 // Events.
-// GCHLOL: Add strings for the report pre-run event.
 $string['event:reportrunstarted'] = 'Report run started';
 $string['event:reportrunstarted:desc'] = 'User with id \'{$a->userid}\' started running report \'{$a->reportname}\' (id {$a->objectid}).';
-// GCHLOL ends.
 $string['event:reportviewed'] = 'Report viewed';
 $string['event:reportexported'] = 'Report exported';
 $string['event:reportcreated'] = 'Report created';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -666,6 +666,7 @@ $string['repositorytoken'] = 'GitHub Access Token';
 $string['repositorytokeninfo'] = 'Optional access token to include with each request. This token requires the Contents Read-only permission at a minimum. See <a target="_blank" href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens">Personal Access Token Docs</a>.';
 
 // Events.
+$string['event:reportrunstarted'] = 'Report run started';
 $string['event:reportviewed'] = 'Report viewed';
 $string['event:reportexported'] = 'Report exported';
 $string['event:reportcreated'] = 'Report created';
@@ -673,6 +674,7 @@ $string['event:reportupdated'] = 'Report updated';
 $string['event:reportdeleted'] = 'Report deleted';
 $string['event:reportimported'] = 'Report imported';
 $string['event:reportduplicated'] = 'Report duplicated';
+$string['event:reportrunstarted:desc'] = 'User with id \'{$a->userid}\' started running report \'{$a->reportname}\' (id {$a->objectid}).';
 $string['event:reportviewed:desc'] = 'User with id \'{$a->userid}\' viewed report \'{$a->reportname}\' (id {$a->objectid}).';
 $string['event:reportexported:desc'] = 'User with id \'{$a->userid}\' exported report \'{$a->reportname}\' (id {$a->objectid}) in format \'{$a->format}\'.';
 $string['event:reportcreated:desc'] = 'User with id \'{$a->userid}\' created report \'{$a->reportname}\' (id {$a->objectid}).';

--- a/lang/en/block_configurable_reports.php
+++ b/lang/en/block_configurable_reports.php
@@ -666,7 +666,10 @@ $string['repositorytoken'] = 'GitHub Access Token';
 $string['repositorytokeninfo'] = 'Optional access token to include with each request. This token requires the Contents Read-only permission at a minimum. See <a target="_blank" href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens">Personal Access Token Docs</a>.';
 
 // Events.
+// GCHLOL: Add strings for the report pre-run event.
 $string['event:reportrunstarted'] = 'Report run started';
+$string['event:reportrunstarted:desc'] = 'User with id \'{$a->userid}\' started running report \'{$a->reportname}\' (id {$a->objectid}).';
+// GCHLOL ends.
 $string['event:reportviewed'] = 'Report viewed';
 $string['event:reportexported'] = 'Report exported';
 $string['event:reportcreated'] = 'Report created';
@@ -674,7 +677,6 @@ $string['event:reportupdated'] = 'Report updated';
 $string['event:reportdeleted'] = 'Report deleted';
 $string['event:reportimported'] = 'Report imported';
 $string['event:reportduplicated'] = 'Report duplicated';
-$string['event:reportrunstarted:desc'] = 'User with id \'{$a->userid}\' started running report \'{$a->reportname}\' (id {$a->objectid}).';
 $string['event:reportviewed:desc'] = 'User with id \'{$a->userid}\' viewed report \'{$a->reportname}\' (id {$a->objectid}).';
 $string['event:reportexported:desc'] = 'User with id \'{$a->userid}\' exported report \'{$a->reportname}\' (id {$a->objectid}) in format \'{$a->format}\'.';
 $string['event:reportcreated:desc'] = 'User with id \'{$a->userid}\' created report \'{$a->reportname}\' (id {$a->objectid}).';

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024051300;
+$plugin->version = 2024051301;
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.1.0';

--- a/viewreport.php
+++ b/viewreport.php
@@ -76,7 +76,9 @@ if ($download && $report->type === "sql") {
     $reportclass->set_forexport(true);
 }
 
-\block_configurable_reports\local\util\event_util::log_report_run_started($context, $report);
+// GCHLOL: Log the report run before executing the report query.
+\block_configurable_reports\event\report_run_started::create_from_report($context, $report)->trigger();
+// GCHLOL ends.
 
 $reportclass->create_report();
 

--- a/viewreport.php
+++ b/viewreport.php
@@ -75,6 +75,12 @@ $download = $download && $format && strpos($report->export, $format . ',') !== f
 if ($download && $report->type === "sql") {
     $reportclass->set_forexport(true);
 }
+
+// GCHLOL: GS-1424. Log before the report runs so a report that crashes the site while
+// running (e.g. an excessively large report) is still traceable, even though it never
+// reaches the post-run report_viewed/report_exported log below.
+\block_configurable_reports\event\report_run_started::create_from_report($context, $report)->trigger();
+
 $reportclass->create_report();
 
 $action = (!empty($download)) ? 'download' : 'view';

--- a/viewreport.php
+++ b/viewreport.php
@@ -76,10 +76,7 @@ if ($download && $report->type === "sql") {
     $reportclass->set_forexport(true);
 }
 
-// GCHLOL: GS-1424. Log before the report runs so a report that crashes the site while
-// running (e.g. an excessively large report) is still traceable, even though it never
-// reaches the post-run report_viewed/report_exported log below.
-\block_configurable_reports\event\report_run_started::create_from_report($context, $report)->trigger();
+\block_configurable_reports\local\util\event_util::log_report_run_started($context, $report);
 
 $reportclass->create_report();
 


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Added a log before a cufigurable report starts running.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have NOT been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.
- [x] Any new test cases have been created and existing test cases updated (excluding epic sub-issues).
